### PR TITLE
Add js0n.h header guards and include js0n.h from js0n.c.

### DIFF
--- a/src/js0n.c
+++ b/src/js0n.c
@@ -1,6 +1,7 @@
 // by jeremie miller - 2014
 // public domain or MIT license, contributions/improvements welcome via github at https://github.com/quartzjer/js0n
 
+#include "js0n.h"
 #include <string.h> // one strncmp() is used to do key comparison, and a strlen(key) if no len passed in
 
 // gcc started warning for the init syntax used here, is not helpful so don't generate the spam, supressing the warning is really inconsistently supported across versions

--- a/src/js0n.h
+++ b/src/js0n.h
@@ -5,6 +5,10 @@
 // vlen = where to store return value length
 // returns pointer to value and sets len to value length, or 0 if not found
 // any parse error will set vlen to the position of the error
+
+#ifndef JS0N_H
+#define JS0N_H
+
 #include <stddef.h>
 #ifdef __cplusplus
 extern "C" {
@@ -14,3 +18,5 @@ const char *js0n(const char *key, size_t klen,
 #ifdef __cplusplus
 } /* extern "C" */
 #endif
+
+#endif /* JS0N_H */


### PR DESCRIPTION
Projects like pktriggercord and deriving from that, libgphoto2, are using js0n.[h,c] sources in their projects. Couple changes came up when doing cleanups on those projects.

First change is to add header guard 'JS0N_H' to js0n.h. This is generally standard practice and wouldn't hurt.

Secondly there is now an '#include "js0n.h"' statement in js0n.c. This is to quiet some compiler warnings about js0n(...) not being previously declared. While it shouldn't be necessary in theory, it shouldn't hurt either.